### PR TITLE
Request to fetch plugin_settings uses version 1.0

### DIFF
--- a/src/main/java/cd/go/plugin/notification/rocketchat/Constants.java
+++ b/src/main/java/cd/go/plugin/notification/rocketchat/Constants.java
@@ -26,6 +26,7 @@ public interface Constants {
 
     // The extension point API version that this plugin understands
     String API_VERSION = "3.0";
+    String PLUGIN_SETTINGS_PROCESSOR_API_VERSION = "1.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));

--- a/src/main/java/cd/go/plugin/notification/rocketchat/PluginRequest.java
+++ b/src/main/java/cd/go/plugin/notification/rocketchat/PluginRequest.java
@@ -20,8 +20,8 @@ import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 
-import static cd.go.plugin.notification.rocketchat.Constants.API_VERSION;
 import static cd.go.plugin.notification.rocketchat.Constants.PLUGIN_IDENTIFIER;
+import static cd.go.plugin.notification.rocketchat.Constants.PLUGIN_SETTINGS_PROCESSOR_API_VERSION;
 
 
 /**
@@ -35,7 +35,7 @@ public class PluginRequest {
     }
 
     public PluginSettings getPluginSettings() throws ServerRequestFailedException {
-        DefaultGoApiRequest request = new DefaultGoApiRequest(Constants.REQUEST_SERVER_GET_PLUGIN_SETTINGS, API_VERSION, PLUGIN_IDENTIFIER);
+        DefaultGoApiRequest request = new DefaultGoApiRequest(Constants.REQUEST_SERVER_GET_PLUGIN_SETTINGS, PLUGIN_SETTINGS_PROCESSOR_API_VERSION, PLUGIN_IDENTIFIER);
         GoApiResponse response = accessor.submit(request);
 
         if (response.responseCode() != 200) {


### PR DESCRIPTION
* The API version used for request processors was same as the Plugin API
  version. In 19.1.0, GoCD core is changed to delink the Plugin API
  version from request processor version - gocd/gocd#5654.
* Ensuring we use the right version of the message when making a call to
  a request process