### PR TITLE
Add information about adding plugin in GoCD hosted on K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ Then you must configure access to rocketchat and room for notifications on plugi
 
 ![settings](settings.png)
 
+##Configuring the plugin for GoCD on Kubernetes using Helm
+
+###Adding the plugin
+- In order to add this plugin, you have to use a local values.yaml file that will override the default [values.yaml](https://github.com/helm/charts/blob/master/stable/gocd/values.yaml) present in the official GoCD helm chart repo.
+- Add the .jar file link from the releases section to the `env.extraEnvVars` section as a new environment variable.
+- The environment variable name must have `GOCD_PLUGIN_INSTALL` prefixed to it.
+- Example
+
+```
+env:
+  extraEnvVars:
+    - name: GOCD_PLUGIN_INSTALL_rocketchat
+      value: https://github.com/tomzo/gocd-rocketchat-plugin/releases/download/0.1.1/gocd-rocketchat-plugin-0.1.1.jar
+```
+- Make sure to add the link of the release you want to use.
+
+- Then applying the local values.yaml that has these values added to it will result in a new Go Server pod being created that has the plugin installed and running.
+
+
 ## Contributing
 
 Please report bugs.


### PR DESCRIPTION
This PR should help people who have their GoCD setup hosted on Kubernetes to add this plugin to their instance.

It contains information on how to add the plugin jar file to the values.yaml.